### PR TITLE
fix invalid bun installation command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Next, you'll want to replace `products` in the `OnchainStoreProvider` with your 
 
 ```sh
 # Install bun in case you don't have it
-bun curl -fsSL <https://bun.sh/install> | bash
+curl -fsSL https://bun.sh/install | bash
 
 # Install packages
 bun i


### PR DESCRIPTION
**What changed? Why?**
The command to install bun if not already installed in the README.md. The earlier command was trying to execute "bun" even before installation.

**How has it been tested?**
Tested the new command on terminal and made sure to verify with official bun documentation.